### PR TITLE
Add an optional and faster git-information-fetching with a C-lang script compiled with gcc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+gitstatus
+.vscode

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ In order for git prompt for Linux to work, the following components must be inst
 1. [Git](https://git-scm.com/).
 2. [Python 3](https://www.python.org/downloads/). In scripts, references to Python 3 appear as `python3`. If you have `python` installed, create a symbolic or hard-drive link with the `ln` command to `python3`, or simply rename them in the `zsh-git-kali-prompt.zsh` file.
 3. For the git information prompt to work correctly, your **Kali Linux** must use the `zsh` UNIX command shell.
+4. GCC (optional). If you are going to use the faster C script compiled to a binary file, you will need `gcc` for the compilation. 
 
 ## Install
 
@@ -34,6 +35,24 @@ In order for git prompt for Linux to work, the following components must be inst
     source $HOME/zsh-git-kali-prompt/zsh-git-kali-prompt.plugin.zsh
     ```
 3.  Restart the console, or write the `zsh` command to start a new session with the applied changes to the `~/.zshrc` settings. 
+4.  Go in a git repository and test it! This only works if you are in a repository.
+
+#### Run the plugin *faster* with the C-lang script (optional)
+
+If you want to reduce delay when reloading the prompt shown in the terminal, you can switch from the python script that collects the git information from the current repository to a binary file coming from a C script. The ulity works the same, it just changes the way of executing the same instructions.
+
+To do this follow the next steps:
+
+1. From the directory where you cloned the repo, compile the C script into a binary file with the next command:
+```sh
+gcc -O2 -o gitstatus gitstatus.c
+```
+
+2. From the shell script `zsh-git-kali-prompt.zsh` replace the env variable `GIT_PROMPT_EXECUTABLE` found in line 9 to `binary`. The line should look like this:
+```sh
+export GIT_PROMPT_EXECUTABLE=${GIT_PROMPT_EXECUTABLE:-"binary"}
+```
+3.  Restart the console so the changes are applied.
 4.  Go in a git repository and test it! This only works if you are in a repository.
 
 ## Deletion

--- a/gitstatus.c
+++ b/gitstatus.c
@@ -1,0 +1,99 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int run_command(const char *cmd, char *result, int max_len) {
+  FILE *fp;
+  fp = popen(cmd, "r");
+  if (fp == NULL) {
+    return -1;
+  }
+  if (fgets(result, max_len, fp) == NULL) {
+    pclose(fp);
+    return -1;
+  }
+  pclose(fp);
+  // Remove trailing newline
+  result[strcspn(result, "\n")] = 0;
+  return 0;
+}
+
+int main() {
+  char result[1024];
+
+  // Check if inside a git repository
+  if (run_command("git rev-parse --is-inside-work-tree 2>/dev/null", result,
+                  sizeof(result)) != 0 ||
+      strcmp(result, "true") != 0) {
+    return 1;
+  }
+
+  // Get current branch name
+  if (run_command("git rev-parse --abbrev-ref HEAD", result, sizeof(result)) !=
+      0) {
+    return 1;
+  }
+  char branch[256];
+  strcpy(branch, result);
+
+  // Get number of staged files
+  run_command("git diff --cached --numstat | wc -l", result, sizeof(result));
+  int staged = atoi(result);
+
+  // Get number of conflicts
+  run_command("git --no-pager diff --name-only --diff-filter=U | wc -l", result,
+              sizeof(result));
+  int conflicts = atoi(result);
+
+  // Get number of modified files
+  run_command("git --no-pager diff --name-only --diff-filter=M | wc -l", result,
+              sizeof(result));
+  int modified = atoi(result);
+
+  // Get number of untracked files
+  run_command("git ls-files --others --exclude-standard | wc -l", result,
+              sizeof(result));
+  int untracked = atoi(result);
+
+  // Get number of deleted files
+  run_command("git --no-pager diff --name-only --diff-filter=D | wc -l", result,
+              sizeof(result));
+  int deleted = atoi(result);
+
+  // Get ahead and behind counts
+  int ahead = 0, behind = 0;
+  char remote_name[256], merge_name[256], remote_ref[256];
+
+  // Check if on a specific branch or detached HEAD
+  if (strcmp(branch, "HEAD") == 0) {
+    run_command("git rev-parse --short HEAD", result, sizeof(result));
+    snprintf(branch, sizeof(branch), ":%s", result);
+  } else {
+    run_command("git config branch.%s.remote", remote_name,
+                sizeof(remote_name));
+    run_command("git config branch.%s.merge", merge_name, sizeof(merge_name));
+
+    if (strcmp(remote_name, ".") == 0) {
+      snprintf(remote_ref, sizeof(remote_ref), "%s", merge_name);
+    } else {
+      snprintf(remote_ref, sizeof(remote_ref), "refs/remotes/%s/%s",
+               remote_name, merge_name + 11);
+    }
+
+    snprintf(result, sizeof(result), "git rev-list --left-right %s...HEAD",
+             remote_ref);
+    FILE *revlist_fp = popen(result, "r");
+    while (fgets(result, sizeof(result), revlist_fp) != NULL) {
+      if (result[0] == '>') {
+        ahead++;
+      } else {
+        behind++;
+      }
+    }
+    pclose(revlist_fp);
+  }
+
+  printf("%s %d %d %d %d %d %d %d\n", branch, ahead, behind, staged, conflicts,
+         modified, untracked, deleted);
+  return 0;
+}

--- a/zsh-git-kali-prompt.zsh
+++ b/zsh-git-kali-prompt.zsh
@@ -5,6 +5,7 @@
 # h: equivalent to dirname
 export __GIT_PROMPT_DIR=${0:A:h}
 
+# Available values: "python3" or "binary"
 export GIT_PROMPT_EXECUTABLE=${GIT_PROMPT_EXECUTABLE:-"python3"}
 
 # Initialize colors.
@@ -46,8 +47,17 @@ function update_current_git_vars() {
     if [[ "$GIT_PROMPT_EXECUTABLE" == "python3" ]]; then
         local gitstatus="$__GIT_PROMPT_DIR/gitstatus.py"
         _GIT_STATUS=`python3 ${gitstatus} 2>/dev/null`
+		elif [[ "$GIT_PROMPT_EXECUTABLE" == "binary" ]]; then
+				local gitstatus="$__GIT_PROMPT_DIR/gitstatus"
+				if [[ -x "$gitstatus" ]]; then
+						_GIT_STATUS=`$gitstatus 2>/dev/null`
+				else
+						echo "Error: gitstatus binary not found or not executable."
+						return
+				fi
     fi
-     __CURRENT_GIT_STATUS=("${(@s: :)_GIT_STATUS}")
+
+	__CURRENT_GIT_STATUS=("${(@s: :)_GIT_STATUS}")
 	GIT_BRANCH=$__CURRENT_GIT_STATUS[1]
 	GIT_AHEAD=$__CURRENT_GIT_STATUS[2]
 	GIT_BEHIND=$__CURRENT_GIT_STATUS[3]


### PR DESCRIPTION
Instructions are also added.

I just found the python script a bit laggy when you clear the console an the script has to re-run to fetch all the git information so I made a C-lang script that executes the same steps that the python one does, so it can be compiled and run directly as a binary from the shell script. It feels much smoother than before, almost like the default Konsole experience.

Thanks for the repo!